### PR TITLE
win: map ERROR_ACCESS_DENIED to UV_EACCES

### DIFF
--- a/src/win/error.c
+++ b/src/win/error.c
@@ -67,6 +67,7 @@ int uv_translate_sys_error(int sys_errno) {
   }
 
   switch (sys_errno) {
+    case ERROR_ACCESS_DENIED:               return UV_EACCES;
     case ERROR_NOACCESS:                    return UV_EACCES;
     case WSAEACCES:                         return UV_EACCES;
     case ERROR_ELEVATION_REQUIRED:          return UV_EACCES;
@@ -151,7 +152,6 @@ int uv_translate_sys_error(int sys_errno) {
     case WSAENOTSOCK:                       return UV_ENOTSOCK;
     case ERROR_NOT_SUPPORTED:               return UV_ENOTSUP;
     case ERROR_BROKEN_PIPE:                 return UV_EOF;
-    case ERROR_ACCESS_DENIED:               return UV_EPERM;
     case ERROR_PRIVILEGE_NOT_HELD:          return UV_EPERM;
     case ERROR_BAD_PIPE:                    return UV_EPIPE;
     case ERROR_NO_DATA:                     return UV_EPIPE;


### PR DESCRIPTION
E.g. when trying to modify a read-only file.

Fixes: https://github.com/nodejs/node/issues/16596
PR-URL: https://github.com/libuv/libuv/pull/1612
Reviewed-By: Ben Noordhuis <info@bnoordhuis.nl>
Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
Reviewed-By: Refael Ackermann <refack@gmail.com>
Reviewed-By: Gireesh Punathil <gpunathi@in.ibm.com>